### PR TITLE
make menu pop behave better on tiling WMs and pass args to gdb

### DIFF
--- a/luigi.h
+++ b/luigi.h
@@ -3946,6 +3946,17 @@ UIWindow *UIWindowCreate(UIWindow *owner, uint32_t flags, const char *cTitle, in
 
 	window->xic = XCreateIC(ui.xim, XNInputStyle, XIMPreeditNothing | XIMStatusNothing, XNClientWindow, window->window, XNFocusWindow, window->window, NULL);
 
+    if(flags & UI_WINDOW_MENU) {
+        Atom property[] = {
+            XInternAtom(ui.display, "_NET_WM_WINDOW_TYPE", true),
+            XInternAtom(ui.display, "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU", true),
+        };
+        XChangeProperty(ui.display, window->window, XInternAtom(ui.display, "_NET_WM_WINDOW_TYPE", true), XA_ATOM, 32, PropModeReplace, (unsigned char*)property, 2);
+        XSetTransientForHint(ui.display, window->window, DefaultRootWindow(ui.display));
+
+    }
+
+
 	return window;
 }
 


### PR DESCRIPTION
This is two small changes, but if you want I can split it up in two pull requests.

- add the `_NET_WM_WINDOW_TYPE_DROPDOWN_MENU` flag to the menu button popup. 
This makes it behave like a menu instead of a separate window. This makes a pretty big difference on tiling window managers.

- pass additional command line args to the gdb process.
This lets you launch gf like `gf2 myProgram --someOther args` instead of having to call `file` and `set args`