### PR TITLE
cleanly close debugger on SIGINT

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -2445,8 +2445,17 @@ extern "C" void CloseDebugger() {
 	pthread_cancel(gdbThread);
 }
 
+void HandleSigInt(int sig) {
+	CloseDebugger();
+	exit(0);
+}
+
 #ifndef EMBED_GF
 int main(int argc, char **argv) {
+	struct sigaction sigintHandler = {};
+	sigintHandler.sa_handler = HandleSigInt;
+	sigaction(SIGINT, &sigintHandler, NULL);
+
 	// Setup GDB arguments.
 	gdbArgv = (char **) malloc(sizeof(char *) * (argc + 1));
 	gdbArgv[0] = (char *) "gdb";


### PR DESCRIPTION
I often close programs by doing a Ctrl-C in the terminal, but when I closed gf this way it leaves the gdb thread running.
This adds a signal handler to call CloseDebugger on SIGINT and terminate the gdb thread.