### PR TITLE
Update warning flags. Add -Wno-unused-result

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,6 @@ else
 	echo "Falling back to builtin font..."
 fi
 
-warning_flags="-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-format-truncation"
+warning_flags="-Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-format-truncation"
 
 g++ gf2.cpp -o gf2 -g -O2 -lX11 -pthread $warning_flags $font_flags


### PR DESCRIPTION
Tried running ./build.sh but got 15 errors all like:

```
gf2.cpp: In function ‘char* LoadFile(const char*, size_t*)’:
gf2.cpp:239:7: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’, declared with attribute warn_unused_result [-Wunused-result]
  239 |  fread(buffer, 1, bytes, f);
      |  ~~~~~^~~~~~~~~~~~~~~~~~~~~
```

Adding this warning flag removed the errors and gf2 can be built successfully.