### PR TITLE
Hardware breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ You can also change the location of the GDB executable. For example,
 path=/home/a/opt/gdb
 ```
 
+You can make `gf2` use hardware breakpoints (`hbreak` instead of `b`). For example,
+
+```ini
+[gdb]
+breakpoint_type=hardware
+```
+
 ### Custom keyboard shortcuts
 
 Keyboard shortcuts are placed in the `[shortcuts]` section. For example,

--- a/windows.cpp
+++ b/windows.cpp
@@ -217,7 +217,7 @@ int DisplayCodeMessage(UIElement *element, UIMessage message, int di, void *dp) 
 				DebuggerSend(buffer, true, false);
 			} else if (element->window->alt || element->window->shift) {
 				char buffer[1024];
-				StringFormat(buffer, 1024, "tbreak %d", line);
+				StringFormat(buffer, 1024, "%s %d", TBREAK_COMMAND, line);
 				EvaluateCommand(buffer);
 				StringFormat(buffer, 1024, "jump %d", line);
 				DebuggerSend(buffer, true, false);


### PR DESCRIPTION
I'm playing around with Linux kernel debugging, and would really prefer to do it in `gf2` :-) And it works beautifully, except that the QEMU `-gdb` link requires the use of hardware breakpoints (`hbreak`/`thbreak`) instead of normal ones (`b`/`tbreak`). My solution is to use hardware breakpoints internally (like clicking in source margin) when the `GF_HWBRK` environment variable is set.

(I considered other solutions which all seemed worse: a UI toggle, `gf2_config.ini`, command-line arguments, and a separate `hgf2` binary.)