### PR TITLE
Prevent busy loop in LogWindow on POLLHUP

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -28,6 +28,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <poll.h>
+#include <time.h>
 
 char *layoutString = (char *) "v(75,h(80,Source,v(50,t(Breakpoints,Commands,Struct),t(Stack,Files,Thread))),h(65,Console,t(Watch,Registers,Data)))";
 // char *layoutString = (char *) "h(70,v(80,Source,Console),v(33,t(Breakpoints,Commands,Struct),v(50,t(Stack,Files,Thread),t(Watch,Registers,Data))))";

--- a/windows.cpp
+++ b/windows.cpp
@@ -2123,6 +2123,10 @@ void *LogWindowThread(void *context) {
 
 	while (true) {
 		poll(&p, 1, 10000);
+		if (p.revents & POLLHUP) {
+            struct timespec t = {.tv_nsec = 10000000};
+		    nanosleep(&t, 0);
+        }
 
 		while (true) {
 			char input[16384];


### PR DESCRIPTION
POLLHUP is returned even if it isn't requested, meaning CPU usage shoots
to 100% if you close your executable while gf2 is still running.

I've just added what I've done to work around it, it's working well enough for my purposes.

EDIT: Absolutely love this little program by the way, just what I've wanted for debugging after giving up on all the IDEs on Linux and switching to terminal GDB.