### PR TITLE
Interleave disassembly with source using CTRL+M

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1076,6 +1076,7 @@ const InterfaceCommand interfaceCommands[] = {
 	{ .label = "Sync with gvim\tF2", { .code = UI_KEYCODE_FKEY(2), .invoke = CommandSyncWithGvim } },
 	{ .label = "Ask GDB for PWD\tCtrl+Shift+P", { .code = UI_KEYCODE_LETTER('P'), .ctrl = true, .shift = true, .invoke = CommandSendToGDB, .cp = (void *) "gf-get-pwd" } },
 	{ .label = "Toggle disassembly\tCtrl+D", { .code = UI_KEYCODE_LETTER('D'), .ctrl = true, .invoke = CommandToggleDisassembly } },
+	{ .label = "Cycle disassembly w/o source, w/ PC order, w/ source order)\tCtrl+M", { .code = UI_KEYCODE_LETTER('M'), .ctrl = true, .invoke = CommandCycleDisassemblySource } },
 	{ .label = "Add watch", { .invoke = CommandAddWatch } },
 	{ .label = "Inspect line", { .code = XK_grave, .invoke = CommandInspectLine } },
 	{ .label = nullptr, { .code = UI_KEYCODE_LETTER('E'), .ctrl = true, .invoke = CommandWatchAddEntryForAddress } },


### PR DESCRIPTION
It's often useful to see the source code interleaved with disassembly.
gdb has options for the "disas" command to accomplish this.
From the gdb output for "help disas":

    With a /s modifier, source lines are included (if available).
    In this mode, the output is displayed in PC address order, and
    file names and contents for all relevant source files are displayed.

    With a /m modifier, source lines are included (if available).
    This view is "source centric": the output is in source line order,
    regardless of any optimization that is present.  Only the main source file
    is displayed, not those of, e.g., any inlined functions.
    This modifier hasn't proved useful in practice and is deprecated
    in favor of /s.

In this change, CTRL+M cycles between using "disas","disas /s","disas /m".
The default CTRL+D view (showing just assembly) remains.
Pressing CTRL+M once shows the source in PC address order.
Pressing CTRL+M again shows the source in source order.
Pressing CTRL+M when not in disassembly view doesn't activate the view,
it just toggles which command is used next time the view is toggled.
Pressing CTRL+M when in disassembly view updates the view display.

The Menu string is a bit verbose and inscrutable and could be improved.