### PR TITLE
Small bug correction with gvim sync in non-English systems

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -961,14 +961,17 @@ void CommandSyncWithGvim(void *) {
 	char *nameEnd = strchr(++name, '"');
 	if (!nameEnd) return;
 	*nameEnd = 0;
-	char *line = strstr(nameEnd + 1, "line ");
+        char *line = nameEnd+1;
+        while(!isdigit(*line) && *line != '\0' ) line++;
 	if (!line) return;
-	int lineNumber = atoi(line + 5);
+	int lineNumber = atoi(line);
 	char buffer2[PATH_MAX];
+
 
 	if (name[0] != '/' && name[0] != '~') {
 		char buffer[1024];
 		StringFormat(buffer, sizeof(buffer), "vim --servername %s --remote-expr \"execute(\\\"pwd\\\")\" | grep '/'", vimServerName);
+
 		FILE *file = popen(buffer, "r");
 		if (!file) return;
 		buffer[fread(buffer, 1, 1023, file)] = 0;


### PR DESCRIPTION
The gvim sync fuction only works in systems that are in English. The CommandSyncWithGvim was searching for the world **line** in the end of a vim command output. In systems that have other works for **line** the function fails.

I've made a small correction that change the function to be language agnostic.

Thanks for the software.
My best,
Rafael Sachetto