### PR TITLE
Local variables view

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -226,6 +226,9 @@ def _gf_basic_type(value):
     return basic_type
 
 def _gf_value(expression):
+    if (expression[0] == ".locals"):
+        expression = expression[1:]
+
     try:
         value = gdb.parse_and_eval(expression[0])
         for index in expression[1:]:
@@ -238,11 +241,21 @@ def _gf_value(expression):
         return None
 
 def gf_typeof(expression):
-    value = _gf_value(expression)
-    if value == None: return
-    print(value.type)
+    if (expression[0] == ".locals"):
+        expression = expression[1:]
+    else:
+        value = _gf_value(expression)
+        if value == None: return
+        print(value.type)
 
 def gf_valueof(expression, format):
+    if (expression[0] == ".locals"):
+        if (len(expression) > 1):
+            expression = expression[1:]
+        else:
+            print('locals')
+            return
+
     value = _gf_value(expression)
     if value == None: return
     result = ''
@@ -278,12 +291,24 @@ def _gf_fields_recurse(value):
     __gf_fields_recurse(basic_type)
 
 def gf_fields(expression):
-    value = _gf_value(expression)
-    if value == None: return
-    basic_type = _gf_basic_type(value)
-    hook_string = _gf_hook_string(basic_type)
-    try: gf_hooks[hook_string](value, None)
-    except: __gf_fields_recurse(basic_type)
+    if (len(expression) == 1 and expression[0] == '.locals'):
+        frame = gdb.selected_frame()
+        block = frame.block()
+        names = set()
+        while block.superblock:
+            for symbol in block:
+                if ((symbol.is_argument or symbol.is_variable) and symbol.needs_frame):
+                    if not (symbol.name in names):
+                        print(symbol.name)
+                        names.add(symbol.name)
+            block = block.superblock
+    else:
+        value = _gf_value(expression)
+        if value == None: return
+        basic_type = _gf_basic_type(value)
+        hook_string = _gf_hook_string(basic_type)
+        try: gf_hooks[hook_string](value, None)
+        except: _gf_fields_recurse(value)
 
 end
 )";

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -152,7 +152,7 @@ bool executableAskDirectory = true;
 Array<InterfaceWindow> interfaceWindows;
 Array<InterfaceCommand> interfaceCommands;
 Array<InterfaceDataViewer> interfaceDataViewers;
-char *layoutString = (char *) "v(75,h(80,Source,v(50,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread))),h(65,Console,t(Watch,Registers,Data)))";
+char *layoutString = (char *) "v(75,h(80,Source,v(50,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread))),h(65,Console,t(Watch,Locals,Registers,Data)))";
 const char *fontPath;
 int fontSizeCode = 13;
 int fontSizeInterface = 11;

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -288,17 +288,17 @@ def gf_fields(expression):
 def gf_locals():
     try:
         frame = gdb.selected_frame()
+        block = frame.block()
     except:
         return
-    block = frame.block()
     names = set()
-    while block.superblock:
+    while block and not (block.is_global or block.is_static):
         for symbol in block:
-            if ((symbol.is_argument or symbol.is_variable) and symbol.needs_frame):
-                if not (symbol.name in names):
-                    print(symbol.name)
-                    names.add(symbol.name)
+            if (symbol.is_argument or symbol.is_variable or symbol.is_constant):
+                names.add(symbol.name)
         block = block.superblock
+    for name in names:
+        print(name)
 
 end
 )";

--- a/windows.cpp
+++ b/windows.cpp
@@ -1535,6 +1535,8 @@ bool WatchLoggerUpdate(char *data) {
 }
 
 void WatchCreateTextboxForRow(WatchWindow *w, bool addExistingText) {
+	if (w->mode == WATCH_LOCALS) return;
+
 	int rowHeight = (int) (UI_SIZE_TEXTBOX_HEIGHT * w->element->window->scale);
 	UIRectangle row = w->element->bounds;
 	row.t += w->selectedRow * rowHeight, row.b = row.t + rowHeight;
@@ -1666,7 +1668,8 @@ int WatchWindowMessage(UIElement *element, UIMessage message, int di, void *dp) 
 	if (message == UI_MSG_PAINT) {
 		UIPainter *painter = (UIPainter *) dp;
 
-		for (int i = (painter->clip.t - element->bounds.t) / rowHeight; i <= w->rows.Length(); i++) {
+		int last = w->rows.Length() + (w->mode == WATCH_NORMAL);
+		for (int i = (painter->clip.t - element->bounds.t) / rowHeight; i < last; i++) {
 			UIRectangle row = element->bounds;
 			row.t += i * rowHeight, row.b = row.t + rowHeight;
 
@@ -1743,7 +1746,7 @@ int WatchWindowMessage(UIElement *element, UIMessage message, int di, void *dp) 
 			WatchWindowMessage(element, UI_MSG_LEFT_DOWN, di, dp);
 			UIMenu *menu = UIMenuCreate(&element->window->e, UI_MENU_NO_SCROLL);
 
-			if (!w->rows[index]->parent) {
+			if (w->mode == WATCH_NORMAL && !w->rows[index]->parent) {
 				UIMenuAddItem(menu, 0, "Edit expression", -1, [] (void *cp) { 
 					WatchCreateTextboxForRow((WatchWindow *) cp, true); 
 				}, w);

--- a/windows.cpp
+++ b/windows.cpp
@@ -1920,6 +1920,7 @@ void WatchWindowUpdate(const char *, UIElement *element) {
 		if (newFrame) {
 			if (w->lastLocalList) free(w->lastLocalList);
 			w->lastLocalList = strdup(evaluateResult);
+
 			char *buffer = strdup(evaluateResult);
 			char *s = buffer;
 			char *end;
@@ -1928,6 +1929,7 @@ void WatchWindowUpdate(const char *, UIElement *element) {
 
 			while ((end = strchr(s, '\n')) != NULL) {
 				*end = '\0';
+				if (strstr(s, "(gdb)")) break;
 				expressions.Add(s);
 				s = end + 1;
 			}
@@ -1937,7 +1939,7 @@ void WatchWindowUpdate(const char *, UIElement *element) {
 				bool matched = false;
 				for (int exprIndex=0; exprIndex < expressions.Length(); exprIndex++) {
 					char *expression = expressions[exprIndex];
-					if (strstr(watch->key, expression)) {
+					if (0 == strcmp(watch->key, expression)) {
 						expressions.Delete(exprIndex);
 						matched = true;
 						break;
@@ -1949,7 +1951,9 @@ void WatchWindowUpdate(const char *, UIElement *element) {
 						if (w->rows[rowIndex] == watch) {
 							w->selectedRow = rowIndex;
 							WatchDeleteExpression(w);
+							watchIndex--;
 							found = true;
+							break;
 						}
 					}
 					assert(found);
@@ -1962,6 +1966,8 @@ void WatchWindowUpdate(const char *, UIElement *element) {
 				w->selectedRow = w->rows.Length();
 				WatchAddExpression(w, expression);
 			}
+
+			w->selectedRow = w->rows.Length();
 
 			free(buffer);
 			expressions.Free();


### PR DESCRIPTION
MOTIVATION:
gf has become my go-to debugger front end, but I have always missed the "locals" view that many debuggers have. Without any prior experience with gdb's python API, I tried my hand at cobbling up a solution.

This isn't finished yet. I'm just sharing something I was trying to do in case there is interest in it, in which case I can work on it more.

USAGE:
As it stands, you can add the expression `.locals` to the watch panel to get a view of all of the local variables. The main problem right now is that the "fields" of the locals view don't seem to update when the scope changes unless you delete the expression and recreate it.

TODO:
 - [x] ⚠️ Fix fields not updating as scope changes.
 - [x] Create new UI panel for locals view, or otherwise separate it from the rest of the watch panel.
 - [x] Decouple locals evaluation from watch expression evaluation, so that every expression isn't being string compared to ".locals" every update.
 - [x] Fix stalling issue.