### PR TITLE
Add usage details to `--help` argument

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1612,7 +1612,8 @@ int main(int argc, char **argv) {
 #endif
 	
 	if (argc == 2 && (0 == strcmp(argv[1], "-?") || 0 == strcmp(argv[1], "-h") || 0 == strcmp(argv[1], "--help"))) {
-		fprintf(stderr, "Read the README.md for help.\n");
+		fprintf(stderr, "Usage: %s [GDB ARGS]\n\n"
+			        "GDB ARGS: Pass any gdb arguments here, they will be forwarded to gdb.\n\nFor more information, view the README.md.\n", argv[0]);
 		return 0;
 	}
 

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1613,7 +1613,7 @@ int main(int argc, char **argv) {
 	
 	if (argc == 2 && (0 == strcmp(argv[1], "-?") || 0 == strcmp(argv[1], "-h") || 0 == strcmp(argv[1], "--help"))) {
 		fprintf(stderr, "Usage: %s [GDB ARGS]\n\n"
-			        "GDB ARGS: Pass any gdb arguments here, they will be forwarded to gdb.\n\nFor more information, view the README.md.\n", argv[0]);
+			        "GDB ARGS: Pass any gdb arguments here, they will be forwarded to gdb.\n\nFor more information, view the README.md (https://github.com/nakst/gf/blob/master/README.md).\n", argv[0]);
 		return 0;
 	}
 


### PR DESCRIPTION
I felt the `--help` to be lacking details on how to use, and didn't have the source code on hand to check the readme for super basic arguments.

I added the relevant information (the fact that it accepts any gdb arguments) to the `--help` print.

It looks like this:

```
$ ./gf2 --help
Usage: ./gf2 [GDB ARGS]

GDB ARGS: Pass any gdb arguments here, they will be forwarded to gdb.

For more information, view the README.md.
$ 
```