### PR TITLE
Use `set -e` instead of `|| exit 1` in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Check GDB is installed and uses the expected prompt.
 gdb --version > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: GDB not detected. You must install GDB to use gf.\n"
 gdb --version > /dev/null 2>&1 || exit 1
@@ -13,4 +15,4 @@ else printf "\033[0;31mWarning\033[0m: FreeType could not be found. The fallback
 uname -m | grep x86_64 > /dev/null && extra_flags="$extra_flags -DUI_SSE2"
 
 # Build the executable.
-g++ gf2.cpp -o gf2 -g -O2 -lX11 -pthread -DUI_NO_COLOR_PICKER $extra_flags -Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-format-truncation || exit 1
+g++ gf2.cpp -o gf2 -g -O2 -lX11 -pthread -DUI_NO_COLOR_PICKER $extra_flags -Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-format-truncation


### PR DESCRIPTION
This does the same thing, but also properly exits if any of the previous commands fail.

See the POSIX man page of  `set`:

```
       -e    When this option is on, when any command fails (for any of the reasons
             listed  in Section 2.8.1, Consequences of Shell Errors or by returning
             an exit status greater than zero), the shell immediately  shall  exit,
             as  if  by  executing  the exit special built-in utility with no argu‐
             ments, with the following exceptions:

              1. The failure of any individual command in a multi-command  pipeline
                 shall  not  cause the shell to exit. Only the failure of the pipe‐
                 line itself shall be considered.

              2. The -e setting shall be ignored when executing the  compound  list
                 following  the while, until, if, or elif reserved word, a pipeline
                 beginning with the !  reserved word, or any command of  an  AND-OR
                 list other than the last.

              3. If  the  exit  status  of a compound command other than a subshell
                 command was the result of a failure while -e  was  being  ignored,
                 then -e shall not apply to this command.

             This  requirement  applies  to the shell environment and each subshell
             environment separately. For example, in:

                 set -e; (false; echo one) | cat; echo two

             the false command causes the subshell to exit without  executing  echo
             one;  however,  echo  two  is  executed because the exit status of the
             pipeline (false; echo one) | cat is zero.
```