### PR TITLE
Fix crashing on expanding empty arrays

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -274,7 +274,7 @@ def __gf_fields_recurse(type):
             if field[1].is_base_class: __gf_fields_recurse(field[1].type)
             else: print(field[0])
     elif type.code == gdb.TYPE_CODE_ARRAY:
-        print('(array)',type.range()[1]+1)
+        print('(array) %d' % (type.range()[1]+1))
 
 def _gf_fields_recurse(value):
     basic_type = _gf_basic_type(value)

--- a/windows.cpp
+++ b/windows.cpp
@@ -1203,7 +1203,7 @@ void WatchInsertFieldRows2(WatchWindow *w, Watch *watch, Array<Watch *> *array) 
 void WatchInsertFieldRows(WatchWindow *w, Watch *watch, int position, bool ensureLastVisible) {
 	Array<Watch *> array = {};
 	WatchInsertFieldRows2(w, watch, &array);
-	w->rows.InsertMany(&array[0], position, array.Length());
+	w->rows.InsertMany(array.array, position, array.Length());
 	if (ensureLastVisible) WatchEnsureRowVisible(w, position + array.Length() - 1);
 	array.Free();
 }


### PR DESCRIPTION
This Pull Request fixes to problems. First one is the application crashing when trying to expand empty arrays or strictures. Second one not working properly with older GDBs. All the details are in the commit messages.

Please, let me know if there are any problems with the Pull Request.

Thank you very much for making such a useful GDB frontend! :heart: 