### PR TITLE
remove stack size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ confirm_command_kill=0
 confirm_command_connect=0
 ```
 
+You can limit count of the backtrace stack frames (default 50).
+
+```ini
+[gdb]
+backtrace_count_limit=50
+```
+
 ### Custom keyboard shortcuts
 
 Keyboard shortcuts are placed in the `[shortcuts]` section. For example,

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -163,6 +163,7 @@ bool restoreWatchWindow;
 struct WatchWindow *firstWatchWindow;
 bool maximize;
 bool confirmCommandConnect = true, confirmCommandKill = true;
+int backtraceCountLimit = 50;
 
 // Current file and line:
 
@@ -699,7 +700,9 @@ void *ControlPipeThread(void *) {
 }
 
 void DebuggerGetStack() {
-	EvaluateCommand("bt 50");
+	char buffer[16];
+	StringFormat(buffer, sizeof(buffer), "bt %d", backtraceCountLimit);
+	EvaluateCommand(buffer);
 	stack.Free();
 
 	const char *position = evaluateResult;
@@ -1231,6 +1234,8 @@ void SettingsLoad(bool earlyPass) {
 					confirmCommandKill = atoi(state.value);
 				} else if (0 == strcmp(state.key, "confirm_command_connect")) {
 					confirmCommandConnect = atoi(state.value);
+				} else if (0 == strcmp(state.key, "backtrace_count_limit")) {
+					backtraceCountLimit = atoi(state.value);
 				}
 			} else if (0 == strcmp(state.section, "commands") && earlyPass && state.keyBytes && state.valueBytes) {
 				presetCommands.Add(state);


### PR DESCRIPTION
Hi,

I was debugging some large code base, and released that I'm not able to see the full stack trace, so decided to check why that is the case.
Personally, I do not see the use case when it would be useful to truncate the stack, but it's possible to make this as an option in config file.
Something like:
```
[gdb]
limit_stack_size = 50
```
What do you think?
