### PR TITLE
Track threads by their assigned id from gdb

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -2577,6 +2577,7 @@ UIElement *LogWindowCreate(UIElement *parent) {
 struct Thread {
 	char frame[127];
 	bool active;
+	int id;
 };
 
 struct ThreadWindow {
@@ -2591,7 +2592,7 @@ int ThreadTableMessage(UIElement *element, UIMessage message, int di, void *dp) 
 		m->isSelected = window->threads[m->index].active;
 
 		if (m->column == 0) {
-			return StringFormat(m->buffer, m->bufferBytes, "%d", m->index + 1);
+			return StringFormat(m->buffer, m->bufferBytes, "%d", window->threads[m->index].id);
 		} else if (m->column == 1) {
 			return StringFormat(m->buffer, m->bufferBytes, "%s", window->threads[m->index].frame);
 		}
@@ -2600,7 +2601,7 @@ int ThreadTableMessage(UIElement *element, UIMessage message, int di, void *dp) 
 
 		if (index != -1) {
 			char buffer[1024];
-			StringFormat(buffer, 1024, "thread %d", index + 1);
+			StringFormat(buffer, 1024, "thread %d", window->threads[index].id);
 			DebuggerSend(buffer, true, false);
 		}
 	}
@@ -2633,6 +2634,7 @@ void ThreadWindowUpdate(const char *, UIElement *_table) {
 		if (!position) break;
 		Thread thread = {};
 		if (position[1] == '*') thread.active = true;
+		thread.id = atoi(position+2);
 		position = strchr(position + 1, '"');
 		if (!position) break;
 		position = strchr(position + 1, '"');


### PR DESCRIPTION
Otherwise a click on a thread to activate will not always work, e.g. when some threads have exited in between. The item index + 1 only workedy by accident when no thread exited or one has only one thread running. Tested with a simple program:
```cpp
#include <iostream>
#include <thread>
#include <unistd.h>
int main() {
  std::cout << "hello threads\n";
  for (int i = 0; i < 10; i++) {
    std::thread fread([] { usleep(100000); });
    fread.join();
  }
  std::cout << "goodbye threads\n";
  return 0;
}
```
By breaking at fread.join(); and watching the thread list, and continuing by pressing `F5`