### PR TITLE
Enable UI SSE2 for OpenBSD/amd64

### DIFF
--- a/build_openbsd.sh
+++ b/build_openbsd.sh
@@ -5,7 +5,7 @@ egdb --version > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: GDB not det
 echo q | egdb | grep "(gdb)" > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: Your copy of GDB appears to be non-standard or has been heavily reconfigured with .gdbinit.\nIf you are using GDB plugins like 'GDB Dashboard' you must remove them,\nas otherwise gf will be unable to communicate with GDB.\n"
 
 # Check if SSE2 is available.
-uname -m | grep x86_64 > /dev/null && extra_flags="$extra_flags -DUI_SSE2"
+[ "$(uname -m)" = amd64 ] && extra_flags="$extra_flags -DUI_SSE2"
 
 # Build the executable.
 c++ gf2.cpp -o gf2 -g -O2 \
@@ -13,4 +13,5 @@ c++ gf2.cpp -o gf2 -g -O2 \
 	-I/usr/X11R6/include -L/usr/X11R6/lib -lX11 \
 	-I/usr/X11R6/include/freetype2 -lfreetype \
 	-DUI_FREETYPE \
+	$extra_flags \
 	-Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers || exit 1


### PR DESCRIPTION
The current build script for OpenBSD does not properly detect SSE2 support in the host CPU. It checks if the machine hardware name is x86_64, which is not a name that OpenBSD uses for any architecture. What uname on Linux reports as x86_64, OpenBSD's uname reports as amd64.

This new build script detects whether the host CPU is AMD64, and in that case defines UI_SSE2.