### PR TITLE
Parse gdb argument from config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ You can pass additional arguments to GDB in the `[gdb]` section. For example,
 argument=-nx
 argument=-ex record
 ```
+"argument" option is obsolete now, please use "arguments"
+
+```ini
+[gdb]
+arguments=-nx
+arguments=-ex record
+```
 
 You can also change the location of the GDB executable. For example,
 

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1224,6 +1224,43 @@ void SettingsLoad(bool earlyPass) {
 					gdbArgv = (char **) realloc(gdbArgv, sizeof(char *) * (gdbArgc + 1));
 					gdbArgv[gdbArgc - 1] = state.value;
 					gdbArgv[gdbArgc] = nullptr;
+                } else if (0 == strcmp(state.key, "arguments")) {
+					char buffer[2048];
+
+					for (size_t i = 0; i < state.valueBytes; i++) {
+						if (isspace(state.value[i])) {
+							continue;
+						}
+
+						size_t argBegin = 0;
+						size_t argEnd = 0;
+
+						if (state.value[i] == '\"') {
+							i++;
+							argBegin = i;
+							for (; i < state.valueBytes && state.value[i] != '\"'; i++);
+							argEnd = i;
+							i++;
+						} else if (state.value[i] == '\'') {
+							i++;
+							argBegin = i;
+							for (; i < state.valueBytes && state.value[i] != '\''; i++);
+							argEnd = i;
+							i++;
+						} else {
+							argBegin = i;
+							i++;
+							for (; i < state.valueBytes && (state.value[i] != '\'' && state.value[i] != '\"' && !isspace(state.value[i])); i++);
+							argEnd = i;
+						}
+
+						StringFormat(buffer, sizeof(buffer), "%.*s", argEnd - argBegin, &state.value[argBegin]);
+
+						gdbArgc++;
+						gdbArgv = (char **) realloc(gdbArgv, sizeof(char *) * (gdbArgc + 1));
+						gdbArgv[gdbArgc - 1] = strdup(buffer);
+						gdbArgv[gdbArgc] = nullptr;
+					}
 				} else if (0 == strcmp(state.key, "path")) {
 					gdbPath = state.value;
 				} else if (0 == strcmp(state.key, "log_all_output") && atoi(state.value)) {


### PR DESCRIPTION
Basically, when passing arguments to gf they are properly parsed by the shell for us, but if we read gdb arguments from config they are not handled properly. This parsing is simple and surely does not handle some cases, but should be good enough.

Also with this change, it is possible to pass multiple arguments in a single argument variable
```
[gdb]
argument=-arg1 val1 -arg2 val2 -ex "set breakpoint ..."
```
#97 