### PR TITLE
deduplicate redundant entries in the Breakpoints window.

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -802,6 +802,14 @@ void DebuggerGetBreakpoints() {
 
 		if (recognised) {
 			realpath(breakpoint.file, breakpoint.fileFull);
+
+			for (int i = 0; i < breakpoints.Length(); i++) {
+				if (strcmp(breakpoints[i].fileFull, breakpoint.fileFull) == 0 &&
+					breakpoints[i].line == breakpoint.line) {
+					goto doNext;
+				}
+			}
+
 			breakpoints.Add(breakpoint);
 		} else {
 			if (!strstr(position, "watchpoint")) goto doNext;


### PR DESCRIPTION
This commit fixes the following bug:
Adding the same `breakpoint` multiple times, adds multiple duplicate entries in the Breakpoints window.
Steps to reproduce:
    1- `gf2 myprogram`
    2- issue the following command multiple times: `b main`
    3- click on the `Breakpoints` window on the right 
you will observe the same entry multiple times shown in the `Breakpoints` window.