### PR TITLE
Add NetBSD build script

### DIFF
--- a/build_netbsd.sh
+++ b/build_netbsd.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Check GDB is installed and uses the expected prompt.
+gdb --version > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: GDB not detected. You must install GDB to use gf.\n"
+echo q | gdb | grep "(gdb)" > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: Your copy of GDB appears to be non-standard or has been heavily reconfigured with .gdbinit.\nIf you are using GDB plugins like 'GDB Dashboard' you must remove them,\nas otherwise gf will be unable to communicate with GDB.\n"
+
+clang++ --version > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: Please install clang or alternatively a newer version of GCC to build gf.\n"
+
+# Check if SSE2 is available.
+[ "$(uname -m)" = amd64 ] && extra_flags="$extra_flags -DUI_SSE2"
+
+# Build the executable.
+clang++ -Wl,-R/usr/X11R7/lib gf2.cpp -o gf2 -g -O2 \
+	-I/usr/local/include -L/usr/local/lib \
+	-I/usr/X11R7/include -L/usr/X11R7/lib -lX11 \
+	-I/usr/X11R7/include/freetype2 -lfreetype -lpthread \
+	-DUI_FREETYPE \
+	$extra_flags \
+	-Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers || exit 1

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -525,7 +525,7 @@ void *DebuggerThread(void *) {
 	pipe(outputPipe);
 	pipe(inputPipe);
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
 	gdbPID = fork();
 	
 	if(gdbPID == 0) {
@@ -1699,6 +1699,7 @@ int main(int argc, char **argv) {
 			for (int i = 0; i < firstWatchWindow->baseExpressions.Length(); i++) {
 				fprintf(f, "%s\n", firstWatchWindow->baseExpressions[i]->key);
 			}
+		        fclose(f);
 		} else {
 			fprintf(stderr, "Warning: Could not save the contents of the watch window; '%s' was not accessible.\n", globalConfigPath);
 		}


### PR DESCRIPTION
The only issue with NetBSD right now is that they ship an older version of GCC (version 7.x from 2017). There are newer versions of GCC available in repo, however, I don't think it will come without creating conflict with the existing one. So instead I've "forced" clang in that script.

Some other changes included - adding the `__NetBSD__`  identifier macro and closing the file stream after ending using it (at main).
