### PR TITLE
fix: display the expanded elements of an array in the right format.

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -1150,6 +1150,7 @@ void WatchAddFields(WatchWindow *w, Watch *watch) {
 		}
 
 		for (int i = 0; i < count; i++) {
+			fields[i].format = watch->format;
 			fields[i].parent = watch;
 			fields[i].arrayIndex = i;
 			watch->fields.Add(&fields[i]);
@@ -1824,6 +1825,14 @@ int WatchWindowMessage(UIElement *element, UIMessage message, int di, void *dp) 
 		if (w->waitingForFormatCharacter) {
 			w->rows[w->selectedRow]->format = (m->textBytes && isalpha(m->text[0])) ? m->text[0] : 0;
 			w->rows[w->selectedRow]->updateIndex--;
+
+			if (w->rows[w->selectedRow]->isArray) {
+				for (int i = 0; i < w->rows[w->selectedRow]->fields.Length(); i++) {
+					w->rows[w->selectedRow]->fields[i]->format = w->rows[w->selectedRow]->format;
+					w->rows[w->selectedRow]->fields[i]->updateIndex--;
+				}
+			}
+
 			w->waitingForFormatCharacter = false;
 		} else if (w->mode == WATCH_NORMAL && w->selectedRow != w->rows.Length() && !w->textbox
 				&& (m->code == UI_KEYCODE_ENTER || m->code == UI_KEYCODE_BACKSPACE || (m->code == UI_KEYCODE_LEFT && !w->rows[w->selectedRow]->open))


### PR DESCRIPTION
Right now if we add a watch expression to inspect the contents of say an array in C ` char buffer[100];`, or just inspect it's contents  in the `Locals` window, and then change the format specifier of the buffer with for example `/x`, this will change it's display format to hexadecimal, but when expanded (`>`) all the elements in the array are not displayed in the hexadecimal format.

This pull request makes sure to synchronize the format of the different fields of the watch object with their parent.