### PR TITLE
relayout event wave propagation with UI_ELEMENT_RELAYOUT_DESCENDENT

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -4063,12 +4063,12 @@ void UIElementMove(UIElement *element, UIRectangle bounds, bool layout) {
 	if (layout) {
 		UIElementMessage(element, UI_MSG_LAYOUT, 0, 0);
 	} else if (element->flags & UI_ELEMENT_RELAYOUT_DESCENDENT) {
+		element->flags &= ~UI_ELEMENT_RELAYOUT_DESCENDENT;
 		for (uint32_t i = 0; i < element->childCount; i++) {
 			UIElementMove(element->children[i], element->children[i]->bounds, false);
 		}
 	}
 
-	element->flags &= ~UI_ELEMENT_RELAYOUT_DESCENDENT;
 }
 
 void _UIElementPaint(UIElement *element, UIPainter *painter) {


### PR DESCRIPTION
The code bellow is telling me: "never set the UI_ELEMENT_RELAYOUT_DESCENDENT flag down the road"

``` C
	} else if (element->flags & UI_ELEMENT_RELAYOUT_DESCENDENT) {
		for (uint32_t i = 0; i < element->childCount; i++) {
			UIElementMove(element->children[i], element->children[i]->bounds, false);
		}
	}
	element->flags &= ~UI_ELEMENT_RELAYOUT_DESCENDENT;
```

But if this can be allowed, this PR should correct some UI bugs I get when using registers tab.
Since I'm not familiar with this code base, my fix may not be the right thing to do.