### PR TITLE
feat: added the ability to enable, disable and delete multiple breakpoints at once

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1032,19 +1032,25 @@ void CommandEnableBreakpoint(void *_index) {
 
 void CommandDeleteSelectedBreakpoints(void *_cp) {
 	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
-		CommandDeleteBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+		char buffer[1024];
+		StringFormat(buffer, 1024, "delete %d", selectedBreakpoints[i]);
+		DebuggerSend(buffer, true, false);
 	}
 }
 
 void CommandDisableSelectedBreakpoints(void *_cp) {
 	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
-		CommandDisableBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+		char buffer[1024];
+		StringFormat(buffer, 1024, "disable %d", selectedBreakpoints[i]);
+		DebuggerSend(buffer, true, false);
 	}
 }
 
 void CommandEnableSelectedBreakpoints(void *_cp) {
 	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
-		CommandEnableBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+		char buffer[1024];
+		StringFormat(buffer, 1024, "enable %d", selectedBreakpoints[i]);
+		DebuggerSend(buffer, true, false);
 	}
 }
 

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -212,6 +212,7 @@ struct Breakpoint {
 };
 
 Array<Breakpoint> breakpoints;
+Array<int> selectedBreakpoints;
 
 // Stack:
 
@@ -1027,6 +1028,24 @@ void CommandEnableBreakpoint(void *_index) {
 	char buffer[1024];
 	StringFormat(buffer, 1024, "enable %d", breakpoint->number);
 	DebuggerSend(buffer, true, false);
+}
+
+void CommandDeleteSelectedBreakpoints(void *_cp) {
+	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
+		CommandDeleteBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+	}
+}
+
+void CommandDisableSelectedBreakpoints(void *_cp) {
+	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
+		CommandDisableBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+	}
+}
+
+void CommandEnableSelectedBreakpoints(void *_cp) {
+	for (int i = 0; i < selectedBreakpoints.Length(); i++) {
+		CommandEnableBreakpoint((void *) (intptr_t)selectedBreakpoints[i]);
+	}
 }
 
 void CommandPause(void *) {

--- a/windows.cpp
+++ b/windows.cpp
@@ -2241,7 +2241,7 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 		int index = UITableHitTest((UITable *) element, element->window->cursorX, element->window->cursorY);
 
 		if (index != -1) {
-			if (element->window->ctrl) {
+			if (element->window->ctrl || element->window->shift) {
 				bool breakpointIsSelected = false;
 				int i;
 				for (i = 0; i < selectedBreakpoints.Length(); i++) {
@@ -2251,6 +2251,20 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 					}
 				}
 				breakpointIsSelected ? selectedBreakpoints.Delete(i) : selectedBreakpoints.Add(index);
+
+				if (element->window->shift) {
+					if (selectedBreakpoints.Length() > 1) {
+						int max = selectedBreakpoints[0];
+						int min = selectedBreakpoints[0];
+						for (int i = 1; i < selectedBreakpoints.Length(); i++) {
+							max = max > selectedBreakpoints[i] ? max : selectedBreakpoints[i];
+							min = min < selectedBreakpoints[i] ? min : selectedBreakpoints[i];
+						}
+
+						selectedBreakpoints.Free();
+						for (int i = min; i <= max; i++) selectedBreakpoints.Add(i);
+					}
+				}
 			} else {
 				selectedBreakpoints.Free();
 				selectedBreakpoints.Add(index);


### PR DESCRIPTION
This PR adds the ability to delete, enable and disable multiple selected breakpoints at once.
The user can select multiple breakpoints by holding the CTRL key and clicking with the left mouse button on the desired breakpoints in the `Breakpoint` window, or by holding down the SHIFT key and selecting a desired range or breakpoints. Then if they choose in the right click menu to `Delete`, `Enable` or `Disable`, the action will affect all the selected breakpoints.