### PR TITLE
fix: accessing the breakpoints array at bad index value.

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -2213,14 +2213,14 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 	} else if (message == UI_MSG_RIGHT_DOWN) {
 		int index = UITableHitTest((UITable *) element, element->window->cursorX, element->window->cursorY);
 
-		Breakpoint *entry = &breakpoints[index];
-
-		if (data->selected.Length() <= 1 || !data->selected.Contains(entry->number, nullptr)) {
-			if (!element->window->ctrl) data->selected.Free();
-			data->selected.Add(entry->number);
-		}
-
 		if (index != -1) {
+			Breakpoint *entry = &breakpoints[index];
+
+			if (data->selected.Length() <= 1 || !data->selected.Contains(entry->number, nullptr)) {
+				if (!element->window->ctrl) data->selected.Free();
+				data->selected.Add(entry->number);
+			}
+
 			UIMenu *menu = UIMenuCreate(&element->window->e, UI_MENU_NO_SCROLL);
 
 			if (data->selected.Length() > 1) {


### PR DESCRIPTION
making sure to not index the breakpoints array at index = -1, otherwise core dump, and we do not like those.