### PR TITLE
fix: handle conditional breakpoints correctly.

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1027,29 +1027,18 @@ void CommandSendToGDB(void *_string) {
 	CommandParseInternal((const char *) _string, false);
 }
 
-void CommandDeleteBreakpoint(void *_index) {
-	int index = (int) (intptr_t) _index;
-	Breakpoint *breakpoint = &breakpoints[index];
-	char buffer[1024];
-	StringFormat(buffer, 1024, "delete %d", breakpoint->number);
-	DebuggerSend(buffer, true, false);
+#define BREAKPOINT_COMMAND(function, action) \
+void function(void *_index) { \
+	int index = (int) (intptr_t) _index; \
+	Breakpoint *breakpoint = &breakpoints[index]; \
+	char buffer[1024]; \
+	StringFormat(buffer, 1024, action " %d", breakpoint->number); \
+	DebuggerSend(buffer, true, false); \
 }
 
-void CommandDisableBreakpoint(void *_index) {
-	int index = (int) (intptr_t) _index;
-	Breakpoint *breakpoint = &breakpoints[index];
-	char buffer[1024];
-	StringFormat(buffer, 1024, "disable %d", breakpoint->number);
-	DebuggerSend(buffer, true, false);
-}
-
-void CommandEnableBreakpoint(void *_index) {
-	int index = (int) (intptr_t) _index;
-	Breakpoint *breakpoint = &breakpoints[index];
-	char buffer[1024];
-	StringFormat(buffer, 1024, "enable %d", breakpoint->number);
-	DebuggerSend(buffer, true, false);
-}
+BREAKPOINT_COMMAND(CommandDeleteBreakpoint, "delete");
+BREAKPOINT_COMMAND(CommandDisableBreakpoint, "disable");
+BREAKPOINT_COMMAND(CommandEnableBreakpoint, "enable");
 
 void CommandPause(void *) {
 	kill(gdbPID, SIGINT);

--- a/windows.cpp
+++ b/windows.cpp
@@ -292,21 +292,50 @@ int DisplayCodeMessage(UIElement *element, UIMessage message, int di, void *dp) 
 	} else if (message == UI_MSG_RIGHT_DOWN && !showingDisassembly) {
 		int result = UICodeHitTest((UICode *) element, element->window->cursorX, element->window->cursorY);
 
+
+#define COMMAND_FOR_EACH_LINE(function, command) \
+		auto function = [](void *_line) { \
+			int line = (int) (intptr_t) _line; \
+			for (int i = 0; i < breakpoints.Length(); i++) { \
+				if (breakpoints[i].line == line && 0 == strcmp(breakpoints[i].fileFull, currentFileFull)) { \
+					command((void *) (intptr_t) i); \
+				} \
+			} \
+		}
+
+		COMMAND_FOR_EACH_LINE(deleteBreakpoints, CommandDeleteBreakpoint);
+		COMMAND_FOR_EACH_LINE(disableBreakpoints, CommandDisableBreakpoint);
+		COMMAND_FOR_EACH_LINE(enableBreakpoints, CommandEnableBreakpoint);
+
+		UIMenu *menu = UIMenuCreate(&element->window->e, UI_MENU_NO_SCROLL);
+		UIMenuAddItem(menu, 0, "Delete", -1, deleteBreakpoints, (void *) (intptr_t)-result);
+
+		bool atLeastOneBreakpointEnabled = false;
 		for (int i = 0; i < breakpoints.Length(); i++) {
 			if (breakpoints[i].line == -result && 0 == strcmp(breakpoints[i].fileFull, currentFileFull)) {
-				UIMenu *menu = UIMenuCreate(&element->window->e, UI_MENU_NO_SCROLL);
-				UIMenuAddItem(menu, 0, "Delete", -1, CommandDeleteBreakpoint, (void *) (intptr_t) i);
-				UIMenuAddItem(menu, 0, breakpoints[i].enabled ? "Disable" : "Enable", -1,
-						breakpoints[i].enabled ? CommandDisableBreakpoint : CommandEnableBreakpoint, (void *) (intptr_t) i);
-				UIMenuShow(menu);
+				if (breakpoints[i].enabled) {
+					atLeastOneBreakpointEnabled = true;
+					break;
+				}
 			}
 		}
+
+		UIMenuAddItem(menu, 0, atLeastOneBreakpointEnabled ? "Disable" : "Enable", -1,
+				atLeastOneBreakpointEnabled ? disableBreakpoints : enableBreakpoints, (void *) (intptr_t) -result);
+
+		UIMenuShow(menu);
 	} else if (message == UI_MSG_CODE_GET_MARGIN_COLOR && !showingDisassembly) {
+		bool breakpointDisabled = false;
 		for (int i = 0; i < breakpoints.Length(); i++) {
 			if (breakpoints[i].line == di && 0 == strcmp(breakpoints[i].fileFull, currentFileFull)) {
-				return breakpoints[i].enabled ? 0xFF0000 : 0x822454;
+				if (breakpoints[i].enabled) {
+					return 0xFF0000;
+					break;
+				} else breakpointDisabled = true;
 			}
 		}
+		if (breakpointDisabled) return 0x822454;
+
 	} else if (message == UI_MSG_PAINT) {
 		element->messageClass(element, message, di, dp);
 
@@ -2206,6 +2235,8 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 		} else if (m->column == 2) {
 			return StringFormat(m->buffer, m->bufferBytes, "%s", entry->enabled ? "yes" : "no");
 		} else if (m->column == 3) {
+			return StringFormat(m->buffer, m->bufferBytes, "%s", entry->condition ? entry->condition : "");
+		} else if (m->column == 4) {
 			if (entry->hit > 0) {
 				return StringFormat(m->buffer, m->bufferBytes, "%d", entry->hit);
 			}
@@ -2290,7 +2321,7 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 }
 
 UIElement *BreakpointsWindowCreate(UIElement *parent) {
-	UITable *table = UITableCreate(parent, 0, "File\tLine\tEnabled\tHit");
+	UITable *table = UITableCreate(parent, 0, "File\tLine\tEnabled\tCondition\tHit");
 	table->e.cp = (BreakpointTableData *) calloc(1, sizeof(BreakpointTableData));
 	table->e.messageUser = TableBreakpointsMessage;
 	return &table->e;


### PR DESCRIPTION
As of right now we don't display conditional breakpoints in the Breakpoints window if there's already a breakpoint at the same line (ex: `b 34` followed by `b 34 if i > 19` will only show the 1st breakpoint in the Breakpoints window). 
This PR adds the ability to have multiple breakpoints at the same line if they have different conditions. To distinguish between them we have added a new column in the `Breakpoints` window to display the condition for each breakpoint.

Deleting, Disabling or Enabling a breakpoint from the marker on the left margin of the code view, will Delete, Disable or Enable all the breakpoints at that line respectively.

The breakpoint marker in the left margin of the code view will only showed in a disabled state if all the breakpoints points at that given line are disabled.