### PR TITLE
refactor: convert watchpoint to a bool.

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -218,7 +218,7 @@ struct Breakpoint {
 	char file[PATH_MAX];
 	char fileFull[PATH_MAX];
 	int line;
-	int watchpoint;
+	bool watchpoint;
 	int hit;
 	bool enabled;
 	char condition[128];
@@ -874,7 +874,7 @@ void DebuggerGetBreakpoints() {
 			if (isspace(*address)) goto doNext;
 			const char *end = strchr(address, '\n');
 			if (!end) goto doNext;
-			breakpoint.watchpoint = atoi(position + 1);
+			breakpoint.watchpoint = true;
 			snprintf(breakpoint.file, sizeof(breakpoint.file), "%.*s", (int) (end - address), address);
 			breakpoints.Add(breakpoint);
 		}

--- a/windows.cpp
+++ b/windows.cpp
@@ -2250,7 +2250,7 @@ int TableBreakpointsMessage(UIElement *element, UIMessage message, int di, void 
 		if (m->column == 0) {
 			return StringFormat(m->buffer, m->bufferBytes, "%s", entry->file);
 		} else if (m->column == 1) {
-			if (entry->watchpoint) return StringFormat(m->buffer, m->bufferBytes, "watch %d", entry->watchpoint);
+			if (entry->watchpoint) return StringFormat(m->buffer, m->bufferBytes, "watch %d", entry->number);
 			else return StringFormat(m->buffer, m->bufferBytes, "%d", entry->line);
 		} else if (m->column == 2) {
 			return StringFormat(m->buffer, m->bufferBytes, "%s", entry->enabled ? "yes" : "no");


### PR DESCRIPTION
Since we introduced the `number` field in the `Breakpoint` type, `watchpoint` can be simplified to a bool.