### PR TITLE
Fix font-finding edgecase with special characters

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1779,7 +1779,7 @@ int GfMain(int argc, char **argv) {
 #ifdef UI_FREETYPE
 	if (!fontPath) {
 		// Ask fontconfig for a monospaced font. If this fails, the fallback font will be used.
-		FILE *f = popen("fc-list | grep `fc-match mono | awk '{ print($1) }'` "
+		FILE *f = popen("fc-list | grep --fixed-strings `fc-match mono | awk '{ print($1) }'` "
 				"| awk 'BEGIN { FS = \":\" } ; { print($1) }'", "r");
 
 		if (f) {

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1779,7 +1779,7 @@ int GfMain(int argc, char **argv) {
 #ifdef UI_FREETYPE
 	if (!fontPath) {
 		// Ask fontconfig for a monospaced font. If this fails, the fallback font will be used.
-		FILE *f = popen("fc-list | grep --fixed-strings `fc-match mono | awk '{ print($1) }'` "
+		FILE *f = popen("fc-list | grep -F `fc-match mono | awk '{ print($1) }'` "
 				"| awk 'BEGIN { FS = \":\" } ; { print($1) }'", "r");
 
 		if (f) {


### PR DESCRIPTION
The brackets in 'NotoSansMono[wght].ttf' were wrongly interpreted by grep as special regex characters, causing the match to fail and the fallback font to be used.