### PR TITLE
fix: strip the `\n` character at the end of the pasted text in a `UITextbox` element.

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -3381,6 +3381,11 @@ int _UITextboxMessage(UIElement *element, UIMessage message, int di, void *dp) {
 				|| (m->code == UI_KEYCODE_INSERT && !element->window->ctrl && !element->window->alt && element->window->shift)) {
 			size_t bytes;
 			char *text = _UIClipboardReadTextStart(element->window, &bytes);
+			if (text[strlen(text) - 1] == '\n') {
+				text[strlen(text) - 1] = '\0';
+				bytes--;
+			}
+
 			if (text) UITextboxReplace(textbox, text, bytes, true);
 			_UIClipboardReadTextEnd(element->window, text);
 		} else {


### PR DESCRIPTION
When pasting for e.g., "test\n" to a UITextbox element a weird character is pasted at the end of the line, this commit fixes the said bug.

I discovered this bug by selecting a line of code all the way to the end in the code view, copying it, and then pasting it to the `textboxInput` where i observed a box like character printed in the textbox.