### PR TITLE
fix: making sure to only set breakpoints when clicking on the left margin with `UI_MSG_LEFT_DOWN`

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -320,7 +320,7 @@ int DisplayCodeMessage(UIElement *element, UIMessage message, int di, void *dp) 
 				UIMenu *menu = UIMenuCreate(&element->window->e, UI_MENU_NO_SCROLL);
 				UIMenuAddItem(menu, 0, "Delete", -1, CommandDeleteAllBreakpointsOnLine, (void *) (intptr_t)-result);
 				UIMenuAddItem(menu, 0, atLeastOneBreakpointEnabled ? "Disable" : "Enable", -1,
-						atLeastOneBreakpointEnabled ? CommandDisableAllBreakpointsOnLine : CommandEnableAllBreakpointsOnLine, 
+						atLeastOneBreakpointEnabled ? CommandDisableAllBreakpointsOnLine : CommandEnableAllBreakpointsOnLine,
 						(void *) (intptr_t) -result);
 				UIMenuShow(menu);
 			}
@@ -2958,7 +2958,7 @@ int TextboxSearchCommandMessage(UIElement *element, UIMessage message, int di, v
 					memcpy(command.description, dash + 3, next - (dash + 3));
 
 					for (int i = 0; command.description[i]; i++) {
-						command.descriptionLower[i] = command.description[i] >= 'A' && command.description[i] <= 'Z' 
+						command.descriptionLower[i] = command.description[i] >= 'A' && command.description[i] <= 'Z'
 							? command.description[i] + 'a' - 'A' : command.description[i];
 					}
 

--- a/windows.cpp
+++ b/windows.cpp
@@ -282,7 +282,7 @@ DISPLAY_CODE_COMMAND_FOR_ALL_BREAKPOINTS_ON_LINE(CommandDisableAllBreakpointsOnL
 DISPLAY_CODE_COMMAND_FOR_ALL_BREAKPOINTS_ON_LINE(CommandEnableAllBreakpointsOnLine,  CommandEnableBreakpoint );
 
 int DisplayCodeMessage(UIElement *element, UIMessage message, int di, void *dp) {
-	if (message == UI_MSG_CLICKED && !showingDisassembly) {
+	if (message == UI_MSG_LEFT_DOWN && !showingDisassembly) {
 		int result = UICodeHitTest((UICode *) element, element->window->cursorX, element->window->cursorY);
 
 		if (result < 0) {


### PR DESCRIPTION
If you're making a selection from right to left until the beginning of a line, and your cursor ends up hovering over the left margin, a breakpoint is set by accident when you lift your finger from the left mouse button.