### PR TITLE
fix: handle `\n` characters when pasting to a `UITextbox` correctly.

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -3387,7 +3387,9 @@ int _UITextboxMessage(UIElement *element, UIMessage message, int di, void *dp) {
 			char *text = _UIClipboardReadTextStart(element->window, &bytes);
 
 			if (text) {
-				if (text[bytes - 1] == '\n') bytes--;
+				for (size_t i = 0; i < strlen(text); i++) {
+					if (text[i] == '\n') text[i] = ' ';
+				}
 				UITextboxReplace(textbox, text, bytes, true);
 			}
 


### PR DESCRIPTION
When pasting text that contains a `\n` characters in it to `UITextbox` a weird character is inserted everywhere there's a new line character. To fix this we simply replace all occurrences of the `\n` character with a empty space.