### PR TITLE
feat: added the ability to customize the line numbers color.

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1160,7 +1160,7 @@ void CommandDonate(void *) {
 const char *themeItems[] = {
 	"panel1", "panel2", "selected", "border", "text", "textDisabled", "textSelected",
 	"buttonNormal", "buttonHovered", "buttonPressed", "buttonDisabled", "textboxNormal", "textboxFocused",
-	"codeFocused", "codeBackground", "codeDefault", "codeComment", "codeString", "codeNumber", "codeOperator", "codePreprocessor",
+	"codeFocused", "codeBackground", "codeDefault", "codeComment", "codeString", "codeNumber", "codeLineNumber", "codeOperator", "codePreprocessor",
 };
 
 void SettingsAddTrustedFolder() {

--- a/luigi2.h
+++ b/luigi2.h
@@ -230,7 +230,7 @@ typedef struct UITheme {
 	uint32_t text, textDisabled, textSelected;
 	uint32_t buttonNormal, buttonHovered, buttonPressed, buttonDisabled;
 	uint32_t textboxNormal, textboxFocused;
-	uint32_t codeFocused, codeBackground, codeDefault, codeComment, codeString, codeNumber, codeOperator, codePreprocessor;
+	uint32_t codeFocused, codeBackground, codeDefault, codeComment, codeString, codeNumber, codeLineNumber, codeOperator, codePreprocessor;
 } UITheme;
 
 typedef struct UIPainter {
@@ -906,6 +906,7 @@ UITheme uiThemeClassic = {
 	.codeComment = 0xFFA11F20,
 	.codeString = 0xFF037E01,
 	.codeNumber = 0xFF213EF1,
+	.codeLineNumber = 0xFFA11F20,
 	.codeOperator = 0xFF7F0480,
 	.codePreprocessor = 0xFF545D70,
 };
@@ -934,6 +935,7 @@ UITheme uiThemeDark = {
 	.codeComment = 0xFFB4B4B4,
 	.codeString = 0xFFF5DDD1,
 	.codeNumber = 0xFFC3F5D3,
+	.codeLineNumber = 0xFFB4B4B4,
 	.codeOperator = 0xFFF5D499,
 	.codePreprocessor = 0xFFF5F3D1,
 };
@@ -2755,7 +2757,7 @@ int _UICodeMessage(UIElement *element, UIMessage message, int di, void *dp) {
 					UIDrawBlock(painter, marginBounds, marginColor);
 				}
 
-				UIDrawString(painter, marginBounds, string + p, 16 - p, ui.theme.codeDefault, UI_ALIGN_RIGHT, NULL);
+				UIDrawString(painter, marginBounds, string + p, 16 - p, ui.theme.codeLineNumber, UI_ALIGN_RIGHT, NULL);
 			}
 
 			if (code->focused == i) {


### PR DESCRIPTION
I believe the line numbers should not have the same color as the code lines, if we look at any text editor/IDE it's pretty much the case, so by default i set the color of the line numbers to be the same as the comments, if you you want me to change the default color please do tell. With this PR even if we disagree every user can customize their **gf** to their liking.
> NOTE: you'll need to update the [wiki](https://github.com/nakst/gf/wiki/Themes) examples 