### PR TITLE
fix: fixed a scaling issue with the vertical scrollbars of `UITable` elements.

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -3216,7 +3216,7 @@ int _UITableMessage(UIElement *element, UIMessage message, int di, void *dp) {
 		table->hScroll->maximum = columnGap;
 		for (int i = 0; i < table->columnCount; i++) { table->hScroll->maximum += table->columnWidths[i] + columnGap; }
 
-		int vSpace = table->vScroll->page = UI_RECT_HEIGHT(element->bounds) - UI_SIZE_TABLE_HEADER;
+		int vSpace = table->vScroll->page = UI_RECT_HEIGHT(element->bounds) - UI_SIZE_TABLE_HEADER * element->window->scale;
 		int hSpace = table->hScroll->page = UI_RECT_WIDTH(element->bounds);
 		_UI_LAYOUT_SCROLL_BAR_PAIR(table);
 	} else if (message == UI_MSG_MOUSE_MOVE || message == UI_MSG_UPDATE) {


### PR DESCRIPTION
This PR fix the following issue: 
If we change the scale value (for e.g., if we set `scale=2` under `[ui]` in `gf2_config.ini`) the last row doesn't show even if we scroll all the way down.