### PR TITLE
Add basic Unicode support

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -2694,12 +2694,16 @@ UIScrollBar *UIScrollBarCreate(UIElement *parent, uint32_t flags) {
 // Code views.
 /////////////////////////////////////////
 
-bool _UICharIsAlpha(int c) {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-}
-
 bool _UICharIsDigit(int c) {
 	return c >= '0' && c <= '9';
+}
+
+bool _UICharIsAlpha(int c) {
+	return (
+		('A' <= c && c <= 'Z') ||
+		('a' <= c && c <= 'z') ||
+		c > 127
+	);
 }
 
 bool _UICharIsAlphaOrDigitOrUnderscore(int c) {

--- a/luigi2.h
+++ b/luigi2.h
@@ -971,14 +971,14 @@ ptrdiff_t Utf8StringLength(const char *cString, ptrdiff_t bytes) {
 #define _UI_ADVANCE_CHAR(index, code, count) index++
 
 #define _UI_SKIP_TAB(ti, text, bytesLeft, tabSize) \
-	if (*text == '\t') while (ti % tabSize) ti++
+	if (*(text) == '\t') while (ti % tabSize) ti++
 
 #define _UI_MOVE_CARET_BACKWARD(caret, text, offset, offset2) caret--
 #define _UI_MOVE_CARET_FORWARD(caret, text, bytes, offset) caret++
 
 #define _UI_MOVE_CARET_BY_WORD(text, bytes, offset) { \
-	char c1 = text[offset - 1]; \
-	char c2 = text[offset]; \
+	char c1 = (text)[offset - 1]; \
+	char c2 = (text)[offset]; \
 	if (_UICharIsAlphaOrDigitOrUnderscore(c1) != _UICharIsAlphaOrDigitOrUnderscore(c2)) break; \
 }
 

--- a/luigi2.h
+++ b/luigi2.h
@@ -1312,7 +1312,7 @@ char *UIStringCopy(const char *in, ptrdiff_t inBytes) {
 int _UIByteToColumn(const char *string, int byte, int bytes, int tabSize) {
 	int ti = 0, i = 0;
 
-	while (i < byte) {
+	while (i < byte && i < bytes) {
 		ti++;
 		_UI_SKIP_TAB(ti, string + i, bytes - i, tabSize);
 		_UI_ADVANCE_CHAR(i, string + i, byte);


### PR DESCRIPTION
This patch adds basic Unicode support to the UI. It relies on Freetype font renderer and is hidden by default behind UI_UNICODE flag. Encoding support is currently limited to UTF-8.

What works:
- Display of all Unicode characters. Tested against (https://github.com/bits/UTF-8-Unicode-Test-Documents/blob/master/UTF-8_sequence_separated/utf8_sequence_0-0x10ffff_assigned_including-unprintable-asis.txt) and (https://github.com/bits/UTF-8-Unicode-Test-Documents/blob/master/UTF-8_sequence_separated/utf8_sequence_0-0x10ffff_assigned_including-unprintable-replaced.txt)
- Handling of invalid UTF-8 input. Invalid characters are replaced with `?` without any other adverse effects.
- Navigation in text using keyboard and mouse, selection, copy-paste, replacements.
- Starting executables from paths with Unicode characters. The path currently needs to be pasted into the textbox.

What could be improved:
- Word-skipping in text with Unicode characters is a bit flaky. To fix this, I suppose that the `IsCharAlpha()` function would have to be much more sophisticated.
- Cursor position selection with mouse and invalid UTF-8 input. Sometimes the cursor is positioned a few characters behind the expected position if the expected position lies inside an invalid UTF-8 sequence. Navigation with keyboard seems to work fine.

What does not work:
- Textboxes currently do not accept Unicode input from keyboard keystrokes. A workaround is to copy-paste it in.

Notes:
- This patch changes the meaning of `carets` in `UIStringSelection` to by how many glyphs the caret is offset from the beginning rather than bytes.
- This patch also fixes a minor rendering bug when a text selection in `UITextbox` contains tabs.

Comments welcome :)