### PR TITLE
avoid assertion fail when restarting program

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -2255,6 +2255,13 @@ void StackSetFrame(UIElement *element, int index) {
 int TableStackMessage(UIElement *element, UIMessage message, int di, void *dp) {
 	if (message == UI_MSG_TABLE_GET_ITEM) {
 		UITableGetItem *m = (UITableGetItem *) dp;
+		
+		// if the index is not validated here, it will cause an assertion to
+		// fail when subscripting `stack`, crashing the program.
+		if ((size_t)m->index >= stack.length) {
+			return 0;
+		}
+		
 		m->isSelected = m->index == stackSelected;
 		StackEntry *entry = &stack[m->index];
 


### PR DESCRIPTION
1. I open gf2
2. I put in the path to a binary I want to run in it, then press "Start"
3. I step a few times by typing `s` in the GDB console
4. I click "Start" again
5. this causes an assertion fail in the `operator[]` for `Array` and crashes

Not sure how optimal my fix is, it's kind of hacky. But it gives the expected behavior, where the program just starts execution again from the beginning.