### PR TITLE
Also set gdbArgv[0] when loading gdb path from settings

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1329,6 +1329,7 @@ void SettingsLoad(bool earlyPass) {
 					}
 				} else if (0 == strcmp(state.key, "path")) {
 					gdbPath = state.value;
+                                        gdbArgv[0] = state.value;
 				} else if (0 == strcmp(state.key, "log_all_output") && atoi(state.value)) {
 					for (int i = 0; i < interfaceWindows.Length(); i++) {
 						InterfaceWindow *window = &interfaceWindows[i];


### PR DESCRIPTION
This is necessary for rust-gdb to work since that is just a symlink to rustup which will select the correct rust-gdb installation at runtime. (Technically, you try to find the path to the actual rust-gdb binary somewhere in ~/.rustup and use that).

In addition, setting argv[0] to the program filename is what most programs should expect anyway.