### PR TITLE
New `args_from_cmd` and `executable_path_from_cmd` config keys

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -170,9 +170,9 @@ char localConfigDirectory[PATH_MAX];
 char localConfigPath[PATH_MAX];
 const char *executablePath;
 const char *executableArguments;
-bool argsFromCmd = false;
-bool executablePathFromCmd = false;
 bool executableAskDirectory = true;
+bool executablePathFromCmd = false;
+bool executableArgumentsFromCmd = false;
 Array<InterfaceWindow> interfaceWindows;
 Array<InterfaceCommand> interfaceCommands;
 Array<InterfaceDataViewer> interfaceDataViewers;
@@ -1379,7 +1379,7 @@ void SettingsLoad(bool earlyPass) {
 				} else if (0 == strcmp(state.key, "ask_directory")) {
 					executableAskDirectory = atoi(state.value);
 				} else if (0 == strcmp(state.key, "args_from_cmd")) {
-					argsFromCmd = atoi(state.value);
+					executableArgumentsFromCmd = atoi(state.value);
 				} else if (0 == strcmp(state.key, "executable_path_from_cmd")) {
 					executablePathFromCmd = atoi(state.value);
 				}
@@ -1802,7 +1802,7 @@ int GfMain(int argc, char **argv) {
 		executablePath = gdbArgv[1];
 	}
 
-	if (argsFromCmd && gdbArgc >= 3) {
+	if (executableArgumentsFromCmd && gdbArgc >= 3) {
 		size_t n = 0;
 		char *buffer = (char *) malloc(PATH_MAX + 1);
 		for (int i = 2; i < gdbArgc; ++i) {
@@ -1812,7 +1812,9 @@ int GfMain(int argc, char **argv) {
 			}
 			buffer[n++] = ' ';
 		}
-		buffer[--n] = '\0';
+		if (n > 0) {
+			buffer[--n] = '\0';
+		}
 		executableArguments = buffer;
 	}
 

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1379,9 +1379,9 @@ void SettingsLoad(bool earlyPass) {
 				} else if (0 == strcmp(state.key, "ask_directory")) {
 					executableAskDirectory = atoi(state.value);
 				} else if (0 == strcmp(state.key, "args_from_cmd")) {
-					argsFromCmd = true;
+					argsFromCmd = atoi(state.value);
 				} else if (0 == strcmp(state.key, "executable_path_from_cmd")) {
-					executablePathFromCmd = true;
+					executablePathFromCmd = atoi(state.value);
 				}
 			} else if (earlyPass && *state.section && *state.key && *state.value) {
 				for (int i = 0; i < interfaceWindows.Length(); i++) {

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -170,6 +170,8 @@ char localConfigDirectory[PATH_MAX];
 char localConfigPath[PATH_MAX];
 const char *executablePath;
 const char *executableArguments;
+bool argsFromCmd = false;
+bool executablePathFromCmd = false;
 bool executableAskDirectory = true;
 Array<InterfaceWindow> interfaceWindows;
 Array<InterfaceCommand> interfaceCommands;
@@ -1376,6 +1378,10 @@ void SettingsLoad(bool earlyPass) {
 					executableArguments = state.value;
 				} else if (0 == strcmp(state.key, "ask_directory")) {
 					executableAskDirectory = atoi(state.value);
+				} else if (0 == strcmp(state.key, "args_from_cmd")) {
+					argsFromCmd = true;
+				} else if (0 == strcmp(state.key, "executable_path_from_cmd")) {
+					executablePathFromCmd = true;
 				}
 			} else if (earlyPass && *state.section && *state.key && *state.value) {
 				for (int i = 0; i < interfaceWindows.Length(); i++) {
@@ -1791,6 +1797,24 @@ int GfMain(int argc, char **argv) {
 		}
 	}
 #endif
+
+	if (executablePathFromCmd && gdbArgc >= 2) {
+		executablePath = gdbArgv[1];
+	}
+
+	if (argsFromCmd && gdbArgc >= 3) {
+		size_t n = 0;
+		char *buffer = (char *) malloc(PATH_MAX + 1);
+		for (int i = 2; i < gdbArgc; ++i) {
+			const char *p = gdbArgv[i];
+			while (p != NULL && *p != '\0') {
+				buffer[n++] = *p++;
+			}
+			buffer[n++] = ' ';
+		}
+		buffer[--n] = '\0';
+		executableArguments = buffer;
+	}
 
 	fontCode = UIFontCreate(fontPath, fontSizeCode);
 	UIFontActivate(UIFontCreate(fontPath, fontSizeInterface));


### PR DESCRIPTION
I've been using `nakst/gf` for quite some time already, and I've noticed, that having the `args_from_cmd` and `executable_path_from_cmd` keys would be pretty convenient. Whenever I open `gf` I constantly have to copy my paths and flags and paste them into the UI text fields. However, now, executable path and command-line arguments will be set automatically, if they are passed, of course.

The implementation is just for a proof of concept, if `nakst` will support the idea, I can provide a proper solution.