### PR TITLE
properly skip leading spaces in Frame string

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -2902,7 +2902,9 @@ void ThreadWindowUpdate(const char *, UIElement *_table) {
 		memcpy(thread.name, position, end - position);
 		thread.name[end - position] = 0;
 
-		position = strchr(end + 1, '0');
+		position = end + 1;
+		while (*position == ' ') position++;
+
 		end = strchr(position, '\n');
 		if (end - position >= (ptrdiff_t) sizeof(thread.frame))
 			end = position + sizeof(thread.frame) - 1;


### PR DESCRIPTION
Hi, I know I'm the one who changed the thread views 'Frame' string last but I recently got an aarch64 laptop and while running gf on it I noticed what I was doing was incorrect. I also realized it was incorrect for the main thread on amd64 because GDB special cases the thread which contains the 'main' function in it's frame.

I've tested this on both amd64 and aarch64 and this gives the correct results in both cases (just the function's name on aarch64 and the function's address and name on amd64 excluding the main thread which doesn't list the function's address).