### PR TITLE
Fixed python exception in watch window

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -245,6 +245,7 @@ bool stackChanged;
 
 const char *pythonCode = R"(py
 
+import gdb.types
 def _gf_hook_string(basic_type):
     hook_string = str(basic_type)
     template_start = hook_string.find('<')


### PR DESCRIPTION
The watch window fails with the following Python exception:
```
Python Exception <class 'AttributeError'>: module 'gdb' has no attribute 'types'
````
Seems like it was probably caused by some update to how gdb manages its internal python libraries. Simply adding an `import gdb.types` at the top of the python code part like shown [here](https://sourceware.org/gdb/current/onlinedocs/gdb.html/gdb_002etypes.html#gdb_002etypes) fixed it for me.

Distro: Arch Linux
GDB version: 16.1
Python version: 3.13.1