### PR TITLE
Round UISplitPane weight in "Copy Layout to Clipboard"

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -1762,7 +1762,7 @@ void GenerateLayoutString(UIElement *e, Array<char> *sb)
 			sb->Add('h');
 		}
 		sb->Add('(');
-		int n = snprintf(buf, sizeof(buf), "%d", (int)(((UISplitPane*)e)->weight*100));
+		int n = snprintf(buf, sizeof(buf), "%d", (int)(((UISplitPane*)e)->weight*100 + 0.5));
 		sb->AddMany(buf, n);
 		sb->Add(',');
 		GenerateLayoutString(e->children[1], sb);


### PR DESCRIPTION
When parsing layout string at startup, UISplitPane weight is set from an integer multiplied by 0.01.
GenerateLayoutString() computes the weight multiplying it by 100 and then casting in to an int.
This may lead to round errors.

For instance, configuring the layout string:
v(**30**,h(**80**,Source,v(**40**,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread,CmdSearch))),h(**60**,Console,t(Watch,Locals,Registers,Data)))

the string generated by "Copy Layout to Clipboard" is:
v(**29**,h(**79**,Source,v(**39**,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread,CmdSearch))),h(**59**,Console,t(Watch,Locals,Registers,Data)))

With the proposed change, the string generated is the starting one:
v(**30**,h(**80**,Source,v(**40**,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread,CmdSearch))),h(**60**,Console,t(Watch,Locals,Registers,Data)))