### PR TITLE
Allow getting full path with gdb even for absolute file path

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -31,7 +31,7 @@ bool DisplaySetPosition(const char *file, int line, bool useGDBToGetFullPath) {
 	if (file && file[0] == '~') {
 		StringFormat(buffer, sizeof(buffer), "%s/%s", getenv("HOME"), 1 + file);
 		file = buffer;
-	} else if (file && file[0] != '/' && useGDBToGetFullPath) {
+	} else if (file && useGDBToGetFullPath) {
 		EvaluateCommand("info source");
 		const char *f = strstr(evaluateResult, "Located in ");
 


### PR DESCRIPTION
This is necessary due to the usage of debuginfod to distribute debug information by some distributions (e.g. Arch Linux). In such a case, the location of source files given by the "bt" will be different from that given by "info source". The former comes from where the package is compiled whereas the latter will be somewhere under ~/.cache/debuginfod_client.

Checking if a path is absolute cannot distinguish both cases.

For example, running "gdb clang++" with debuginfod enabled (with "set debuginfod enabled on" and appropriate DEBUGINFOD_URLS set) and stopping at main with "start":

Output of "bt":

  (gdb) bt
  #0  main () at /usr/src/debug/clang/clang-19.1.7.src/build/tools/driver/clang-driver.cpp:15

Output of "info source"

  (gdb) info source
  Current source file is /usr/src/debug/clang/clang-19.1.7.src/build/tools/driver/clang-driver.cpp
  Compilation directory is /usr/src/debug/clang/clang-19.1.7.src/build
  Located in /home/kenkwok/.cache/debuginfod_client/26bd1c4553c96fda902722481961f99b194900ea/source-d8de072c-#usr#src#debug#clang#clang-19.1.7.src#build#tools#driver#clang-driver.cpp
  Contains 18 lines.
  Source language is c++.
  Producer is GNU GIMPLE 14.2.1 20250207 -march=x86-64 -mtune=generic -mno-omit-leaf-frame-pointer -g -g1 -O3 -O3 -O2 -O3 -fno-openmp -fno-openacc -fcf-protection=full -funwind-tables -fno-plt -fexceptions -fstack-clash-protection -fcf-protection=full -fno-omit-frame-pointer -fPIC -fno-semantic-interposition -fno-lifetime-dse -ffunction-sections -fdata-sections -fno-common -fno-strict-aliasing -fltrans.
  Compiled with DWARF 5 debugging format.
  Does not include preprocessor macro info.
  (gdb)

In both case, the path is absolute but the path in the former case does not exist as Arch is not a source-based distro.