### PR TITLE
fix: Suppress font loading error

### DIFF
--- a/luigi2.h
+++ b/luigi2.h
@@ -5442,7 +5442,6 @@ void _UIInitialiseCommon() {
 
 #ifdef UI_FREETYPE
 	FT_Init_FreeType(&ui.ft);
-	UIFontActivate(UIFontCreate(_UI_TO_STRING_2(UI_FONT_PATH), 11));
 #else
 	UIFontActivate(UIFontCreate(0, 0));
 #endif


### PR DESCRIPTION
Problem: If FreeType is installed, gf will run a seemingly needless function call that will always error regardless if the font path is correct.

Solution: Remove the UIFontActivate call. Its absence doesn't break font loading from the config file.

Fix #208