### PR TITLE
Workaround for build failures when glibc version is lower than 2.26

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,11 +6,17 @@ gdb --version > /dev/null 2>&1 || exit 1
 echo q | gdb | grep "(gdb)" > /dev/null 2>&1 || printf "\033[0;31mWarning\033[0m: Your copy of GDB appears to be non-standard or has been heavily reconfigured with .gdbinit.\nIf you are using GDB plugins like 'GDB Dashboard' you must remove them,\nas otherwise gf will be unable to communicate with GDB.\n"
 
 # Check if FreeType is available.
-if [ -d /usr/include/freetype2 ]; then extra_flags="$extra_flags -lfreetype -D UI_FREETYPE -I /usr/include/freetype2"; 
+if [ -d /usr/include/freetype2 ]; then extra_flags="$extra_flags -lfreetype -D UI_FREETYPE -I /usr/include/freetype2";
 else printf "\033[0;31mWarning\033[0m: FreeType could not be found. The fallback font will be used.\n"; fi
 
 # Check if SSE2 is available.
 uname -m | grep x86_64 > /dev/null && extra_flags="$extra_flags -DUI_SSE2"
+
+# check if GLIBC version less that 2.26
+GLIBC_V_NUM=$(ldd --version | head -n1 | grep -oP '\d+\.\d+' | head -n1)
+if [ "$(printf '%s\n' "$GLIBC_V_NUM" "2.26" | sort -V | head -n1)" = "$GLIBC_V_NUM" ] && [ "$GLIBC_V_NUM" != "2.26" ]; then
+    extra_flags="$extra_flags -DGLIBC_LT_2_26";
+fi
 
 # Build the executable.
 g++ gf2.cpp -o gf2 -g -O2 -lX11 -pthread $extra_flags -Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-format-truncation || exit 1

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -567,7 +567,7 @@ void *DebuggerThread(void *) {
 	pipe(outputPipe);
 	pipe(inputPipe);
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(GLIBC_LT_2_26) || defined(__APPLE__)
 	gdbPID = fork();
 
 	if(gdbPID == 0) {
@@ -1575,7 +1575,7 @@ void InterfaceAddBuiltinWindowsAndCommands() {
 			.shortcut = { .invoke = CommandAddWatch } });
 	interfaceCommands.Add({ .label = "Inspect line",
 			.shortcut = { .code = UI_KEYCODE_BACKTICK, .invoke = CommandInspectLine } });
-	interfaceCommands.Add({ .label = "Copy Layout to Clipboard", 
+	interfaceCommands.Add({ .label = "Copy Layout to Clipboard",
 			.shortcut = { .invoke = CopyLayoutToClipboard } });
 	interfaceCommands.Add({ .label = nullptr,
 			.shortcut = { .code = UI_KEYCODE_LETTER('E'), .ctrl = true, .invoke = CommandWatchAddEntryForAddress } });


### PR DESCRIPTION
While watching tsoding's [YouTube channel](https://www.youtube.com/tsoding), I noticed that he uses a tool called `gf` and found its debugging interface quite impressive. So I tried it on an old CentOS 7.9 system, but encountered the following error, which I then attempted to fix.

<img width="1053" height="324" alt="f30fb4cea718f58f4f0cbf63881c937d" src="https://github.com/user-attachments/assets/d83483f2-82c2-4eb1-a8a5-6a8dc33d41d4" />
