### PR TITLE
Fix being able to delete locals and WatchWindow::selectedRow becoming negative

### DIFF
--- a/windows.cpp
+++ b/windows.cpp
@@ -2104,10 +2104,12 @@ int WatchWindowMessage(UIElement *element, UIMessage message, int di, void *dp) 
 		UIElementRefresh(element);
 	}
 
+    if (w->selectedRow > WatchLastRow(w)) {
+		w->selectedRow = WatchLastRow(w);
+	}
+
 	if (w->selectedRow < 0) {
 		w->selectedRow = 0;
-	} else if (w->selectedRow > WatchLastRow(w)) {
-		w->selectedRow = WatchLastRow(w);
 	}
 
 	return result;

--- a/windows.cpp
+++ b/windows.cpp
@@ -2023,7 +2023,7 @@ int WatchWindowMessage(UIElement *element, UIMessage message, int di, void *dp) 
 				&& (m->code == UI_KEYCODE_ENTER || m->code == UI_KEYCODE_BACKSPACE || (m->code == UI_KEYCODE_LEFT && !w->rows[w->selectedRow]->open))
 				&& !w->rows[w->selectedRow]->parent) {
 			WatchCreateTextboxForRow(w, true);
-		} else if (m->code == UI_KEYCODE_DELETE && !w->textbox
+		} else if (w->mode == WATCH_NORMAL && m->code == UI_KEYCODE_DELETE && !w->textbox
 				&& w->selectedRow != w->rows.Length() && !w->rows[w->selectedRow]->parent) {
 			WatchDeleteExpression(w);
 		} else if (m->textBytes && m->text[0] == '/' && w->selectedRow != w->rows.Length()) {


### PR DESCRIPTION
This pull requests fixes #219, which consists of two issues. 

First, the user is able to delete rows from the locals window, which seems unintended. To fix this, a check is inserted that ensures that the delete key only deletes rows if the affected window is a normal watch window, not a locals window.

If this feature was intended, I apologize.

Secondly, when deleting rows from the locals window, the index variable `WatchWindow::selectedRow` could become negative. This was due to assigning to it the result of `WatchLastRow()`, which could return -1 if both `WatchWindow` members `rows.Length()` and `extraRows` were equal to 0. As this index was only checked for inequality to `rows.Length()` when deleting, an out of bounds array access was performed.

This seems to only have been a problem when able to delete from the locals window, as otherwise `extraRows` is not 0. If the behaviour of deleting from the locals window is intended, this fixes a crash. And even it's not intended, ensuring the variable doesn't go negative is probably a good idea.

Thanks for making a great program.