### PR TITLE
Add version numbers #165; proposal

### DIFF
--- a/gf2.cpp
+++ b/gf2.cpp
@@ -36,6 +36,12 @@ extern "C" {
 #include "luigi2.h"
 }
 
+
+// Version Numbers
+#define VER_MAJOR 0
+#define VER_MINOR 9
+#define VER_PATCH 1
+
 // Data structures:
 
 template <class T>
@@ -1837,13 +1843,17 @@ void CopyLayoutToClipboard(void *cp)
 }
 
 int GfMain(int argc, char **argv) {
-	if (argc == 2 && (0 == strcmp(argv[1], "-?") || 0 == strcmp(argv[1], "-h") || 0 == strcmp(argv[1], "--help"))) {
-		fprintf(stderr, "Usage: %s [GDB args]\n\n"
-			        "GDB args: Pass any GDB arguments here, they will be forwarded to GDB.\n\n"
-				"For more information, view the README at https://github.com/nakst/gf/blob/master/README.md.\n", argv[0]);
+	if (argc == 2 && (0 == strcmp(argv[1], "-v") || 0 == strcmp(argv[1], "--version"))) {
+		fprintf(stdout, "%s %d.%d.%d\n", argv[0], VER_MAJOR, VER_MINOR, VER_PATCH);
+		return 1;	
+	} else if (argc == 2 && (0 == strcmp(argv[1], "-?") || 0 == strcmp(argv[1], "-h") || 0 == strcmp(argv[1], "--help"))) {
+		fprintf(stderr, "Usage: %s [GDB args]\n"
+				"Version: %d.%d.%d\n\n"
+				"GDB args: Pass any GDB arguments here, they will be forwarded to GDB.\n\n"
+				"For more information, view the README at https://github.com/nakst/gf/blob/master/README.md.\n",
+			argv[0], VER_MAJOR, VER_MINOR, VER_PATCH);
 		return 1;
 	}
-
 	struct sigaction sigintHandler = {};
 	sigintHandler.sa_handler = [] (int) { DebuggerClose(); exit(0); };
 	sigaction(SIGINT, &sigintHandler, nullptr);


### PR DESCRIPTION
I've also had the same problem as mentioned in #165: to prepare a package for OpenIndiana/Illumos, some kind of versioning mechanism is required; but not the Git sha commit. So I added one, and found #165.

I've used MAJOR.MINOR.PATH; but maybe a major and minor is enough?

These are implemented as defines because we can use #ifdef, .. in the code to accomodate code changes. i.e.,, breaking API modifications, support for different GDB versions, ...

Added a new option '-v'  (--version) and the version appears with -h.

I've also used this as the version number 0.9.1; but this is a completelly random sellection. What version should I change this to read? and please advise about the implementation.