### PR TITLE
Add Makefile, currently for Linux and OpenIndiana/Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,117 @@
+#
+# MIT License
+# 
+# Copyright (c) 2026 mebenn (Benny Lyons) and others
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# Usage:
+#        make         -> builds the standard gf2
+#        make clean   -> clean-up
+#        make check   -> for developers, add what you'd like here
+#                        currently display flags for your OS
+# Use only GNU make, make without any targets just builds a staandard
+#
+OSTYPE := $(shell uname -s)
+
+#
+# Linux
+#
+ifeq ($(OSTYPE),Linux)
+	OSFLAG += -D LINUX
+	CPUARCH := $(shell uname -m)
+	ifeq ($(CPUARCH),x86_64)
+		LDFLAGS = -DUI_SSE2
+	endif
+	ifeq ("$(wildcard "/usr/include/freetype2")", "")
+		LDFLAGS += -lfreetype -D UI_FREETYPE -I/usr/include/freetype2
+	else
+		$(warning FreeType fonts coulld not be found, defecting to defaults)
+	endif
+endif
+
+#
+# OpenIndiana/Illumos
+#
+ifeq ($(OSTYPE),SunOS)
+	OSFLAG += -D SunOS
+	CPUARCH := $(shell isainfo -k)
+	ifeq ($(CPUARCH),amd64)
+		LDFLAGS += -DUI_SSE2
+	endif
+	ifeq ("$(wildcard "/usr/include/freetype2")", "")
+		LDFLAGS += -lfreetype -D UI_FREETYPE -I/usr/include/freetype2
+	else
+		$(warning FreeType fonts coulld not be found, defecting to defaults)
+	endif
+endif
+
+# TODO:
+# FreeBSD
+#
+ifeq ($(OSTYPE),FreeBSD)
+	OSFLAG += FreeBSD
+endif
+
+# TODO:
+# OpenBSD
+#
+ifeq ($(OSTYPE),OpenBSD)
+		OSFLAG += OpenBSD
+endif
+
+#TODO:
+# NetBSD
+#
+ifeq ($(OSTYPE),NetBSD)
+	OSFLAG += NetBSD
+endif
+
+# TODO:
+# MacOS
+#
+ifeq ($(OSTYPE),Darwin)
+	OSFLAG += -D OSX
+endif
+
+
+APP=gf2
+
+
+CXX=g++
+CXXFLAGS=-g -O2 -Wall -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-format-truncation 
+LDLIBS = -lX11 -pthread 
+
+
+$(APP): $(APP).o
+	$(CXX) $^ -o $@ $(LDLIBS) $(LDFLAGS)
+$(APP).o: $(APP).cpp
+	$(CXX)   -c $< -o $@ $(LDFLAGS) $(CXXFLAGS) 
+
+
+.PHONY: clean 
+clean:
+	rm -f ./*.o $(APP)
+.PHONY: check
+check:
+	rm -f ./*.o $(APP)
+	$(warning $(LDFLAGS) $(OSFLAG) )
+
+


### PR DESCRIPTION
Need a makefile for OpenIndiana, so I added one. Currently only for both Linux and OpenIndiana, I didn't get time for the other *BSDs, but I can finish if anyone is interested. Just llet me know; but I might require some help as I'm not going to install a load of BSDs, so for each OS a tester would be good (except for Linux and OpenIndiana which I've already quickly tested).
Using the current scripts on a build server, i.e., Jenkins, is not ideal. If the admin has to make a small change and kicks-off the build again for the entire system and a load of packages start to rebuild from scratch is not ideal for the admin.

I've also noticed that some users want to install GDB if it isn't already installed in a build script! Don't do that; if someone wants, for example, to extend the makefile and shoots off a build script on some *BSD just to check, and each time a GDB gets installed, although I just would like to build!!!  Installing GDB if it hasn't already been installed is the responsibility of a _package manager_. gf2 should be made to have a dependency on GDB 
Remember the Unix Moto: Do one thing and do it well!
build.sh should only build.
If you'd like GDB to be installed, then add a new script build_and_install_gdb, or whatever; or when you start gf2, issue a warning: GDB not installed....and possibley exit.

The code in the Makefille needs some clean up: I've got a load of repeated code for the various operating systems; so as soon as I get time I'll update, assuming people are interested.

Idea: if you'd like to keep the scripts, it might be better to use only one script. The master script should detect the OS (and not the poor user) and call the appropriate script. Interested or why bother?

What about automaticaly compiling the extensions as standard?  Is there a reason against doing somethingh like this?


