### PR TITLE
Expose font index

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can change the font, user interface scaling, window width and height in the 
 [ui]
 scale=1.5
 font_path=/usr/share/fonts/TTF/DejaVuSansMono.ttf
+font_index=0
 font_size_interface=17
 font_size_code=20
 width=800
@@ -122,6 +123,11 @@ height=600
 ```
 
 To change the font, FreeType must have been available when you compiled gf. You can enable subpixel font rendering by recompiling with `extra_flags=-DUI_FREETYPE_SUBPIXEL ./build.sh`.
+
+To select particular variation of a font from the file you have to obtain its font index. For example, this can be done using command like this:
+```bash
+fc-scan --format '%{family} | %{style} | index=%{index}\n' /usr/share/fonts/TTF/IosevkaSlab.ttc | grep 'Iosevka Slab |'
+```
 
 If you don't want the execution pointer to be always in the middle of the code window, you can disable this behaviour:
 

--- a/gf2.cpp
+++ b/gf2.cpp
@@ -178,6 +178,7 @@ Array<InterfaceDataViewer> interfaceDataViewers;
 Array<ReceiveMessageType> receiveMessageTypes;
 char *layoutString = (char *) "v(75,h(80,Source,v(50,t(Exe,Breakpoints,Commands,Struct),t(Stack,Files,Thread,CmdSearch))),h(65,Console,t(Watch,Locals,Registers,Data)))";
 const char *fontPath;
+int fontIndex = 0;
 int fontSizeCode = 13;
 int fontSizeInterface = 11;
 float uiScale = 1;
@@ -1286,6 +1287,8 @@ void SettingsLoad(bool earlyPass) {
 			} else if (0 == strcmp(state.section, "ui") && earlyPass) {
 				if (0 == strcmp(state.key, "font_path")) {
 					fontPath = state.value;
+				} else if (0 == strcmp(state.key, "font_index")) {
+					fontIndex = atoi(state.value);
 				} else if (0 == strcmp(state.key, "font_size")) {
 					fontSizeInterface = fontSizeCode = atoi(state.value);
 				} else if (0 == strcmp(state.key, "font_size_code")) {
@@ -1884,8 +1887,8 @@ int GfMain(int argc, char **argv) {
 	}
 #endif
 
-	fontCode = UIFontCreate(fontPath, fontSizeCode);
-	UIFontActivate(UIFontCreate(fontPath, fontSizeInterface));
+	fontCode = UIFontCreate(fontPath, fontIndex, fontSizeCode);
+	UIFontActivate(UIFontCreate(fontPath, fontIndex, fontSizeInterface));
 
 	windowMain = UIWindowCreate(0, maximize ? UI_WINDOW_MAXIMIZE : 0, "gf2", uiWidth, uiHeight);
 	windowMain->scale = uiScale;

--- a/luigi2.h
+++ b/luigi2.h
@@ -830,7 +830,7 @@ void UIColorToRGB(float hue, float saturation, float value, uint32_t *rgb);
 
 char *UIStringCopy(const char *in, ptrdiff_t inBytes);
 
-UIFont *UIFontCreate(const char *cPath, uint32_t size);
+UIFont *UIFontCreate(const char *cPath, uint32_t index, uint32_t size);
 UIFont *UIFontActivate(UIFont *font); // Returns the previously active font.
 
 #ifdef UI_DEBUG
@@ -5173,7 +5173,7 @@ void UIDrawGlyph(UIPainter *painter, int x0, int y0, int c, uint32_t color) {
 	}
 }
 
-UIFont *UIFontCreate(const char *cPath, uint32_t size) {
+UIFont *UIFontCreate(const char *cPath, uint32_t index, uint32_t size) {
 	UIFont *font = (UIFont *) UI_CALLOC(sizeof(UIFont));
 
 #ifdef UI_FREETYPE
@@ -5184,7 +5184,7 @@ UIFont *UIFontCreate(const char *cPath, uint32_t size) {
 	font->glyphOffsetsY = (int *) UI_CALLOC(sizeof(int) * (_UNICODE_MAX_CODEPOINT + 1));
 #endif
 	if (cPath) {
-		int ret = FT_New_Face(ui.ft, cPath, 0, &font->font);
+		int ret = FT_New_Face(ui.ft, cPath, index, &font->font);
 		if (ret == 0) {
 			FT_Select_Charmap(font->font, FT_ENCODING_UNICODE);
 			if (FT_HAS_FIXED_SIZES(font->font) && font->font->num_fixed_sizes) {
@@ -5209,7 +5209,7 @@ UIFont *UIFontCreate(const char *cPath, uint32_t size) {
 			font->isFreeType = true;
 			return font;
 		} else
-			printf("Cannot load font %s : %d\n", cPath, ret);
+			printf("Cannot load font %s(%d) : %d\n", cPath, index, ret);
 	}
 #endif
 


### PR DESCRIPTION
This PR add ui option and alters luigi to make it possible to pass font index down to freetype allowing selection of font kind from the file.

For example, if you try to use Iosevka font, index 0 refers to extra light which is almost transparent making it practically unusable.

[Font index structure](https://freetype.org/freetype2/docs/reference/ft2-face_creation.html#ft_open_face) is a little more complicated, but I think first 16 bits should be enough for most use cases.